### PR TITLE
Build libpng ourselves

### DIFF
--- a/scripts/build-ffmpeg
+++ b/scripts/build-ffmpeg
@@ -108,11 +108,15 @@ if [ ! -e $outputfile ]; then
     extract zlib https://www.zlib.net/zlib-1.2.11.tar.gz
     build zlib
 
-    # build xml2 (uses xz and zlib)
+    # build png (requires zlib)
+    extract png http://deb.debian.org/debian/pool/main/libp/libpng1.6/libpng1.6_1.6.37.orig.tar.gz
+    build png CPPFLAGS=-I$destdir/include
+
+    # build xml2 (requires xz and zlib)
     extract xml2 ftp://xmlsoft.org/libxml2/libxml2-sources-2.9.10.tar.gz
     build xml2 --without-python
 
-    # build freetype
+    # build freetype (requires png)
     extract freetype https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.gz
     build freetype
 


### PR DESCRIPTION
This avoids picking up homebrew's libpng on OS X which may not be built
for the target OS X version.