### PR TITLE
Build gettext ourselves

### DIFF
--- a/scripts/build-ffmpeg
+++ b/scripts/build-ffmpeg
@@ -116,6 +116,10 @@ if [ ! -e $outputfile ]; then
     extract xml2 ftp://xmlsoft.org/libxml2/libxml2-sources-2.9.10.tar.gz
     build xml2 --without-python
 
+    # build gettext (requires xml2)
+    extract gettext https://ftp.gnu.org/pub/gnu/gettext/gettext-0.20.2.tar.gz
+    build gettext --disable-java --with-included-libunistring
+
     # build freetype (requires png)
     extract freetype https://download.savannah.gnu.org/releases/freetype/freetype-2.10.1.tar.gz
     build freetype


### PR DESCRIPTION
This avoids picking up homebrew's libintl on OS X which may not be built
for the target OS X version.