### PR TITLE
Stop setting CFLAGS=-mmacosx-version-min=10.9

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -37,7 +37,6 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: scripts\build-ffmpeg.bat C:\cibw\vendor
           CIBW_BUILD: cp38-*
           CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH=/tmp/vendor/lib:$LD_LIBRARY_PATH
-          CIBW_ENVIRONMENT_MACOS: CFLAGS=-mmacosx-version-min=10.9
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python scripts/inject-dll.py {wheel} {dest_dir} C:\cibw\vendor\bin
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_COMMAND: python -c "import dummy"


### PR DESCRIPTION
cibuildwheel already sets MACOSX_DEPLOYMENT_TARGET