### PR TITLE
Do not touch LD_LIBRARY_PATH while building

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -36,7 +36,7 @@ jobs:
           CIBW_BEFORE_BUILD: python scripts/build-ffmpeg.py /tmp/vendor
           CIBW_BEFORE_BUILD_WINDOWS: scripts\build-ffmpeg.bat C:\cibw\vendor
           CIBW_BUILD: cp38-*
-          CIBW_ENVIRONMENT_LINUX: LD_LIBRARY_PATH=/tmp/vendor/lib:$LD_LIBRARY_PATH
+          CIBW_REPAIR_WHEEL_COMMAND_LINUX: LD_LIBRARY_PATH=/tmp/vendor/lib:$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: python scripts/inject-dll.py {wheel} {dest_dir} C:\cibw\vendor\bin
           CIBW_SKIP: "*musllinux*"
           CIBW_TEST_COMMAND: python -c "import dummy"


### PR DESCRIPTION
Altering LD_LIBRARY_PATH can break tools such as `yum`.

We only need to set LD_LIBRARY_PATH when "repairing" the wheel, that is
when pulling in all the required libraries.