### PR TITLE
[windows] disable mediafoundation support

### DIFF
--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -302,6 +302,7 @@ if not os.path.exists(output_tarball):
             build_arguments=[
                 "--disable-alsa",
                 "--disable-doc",
+                "--disable-mediafoundation",
                 "--enable-fontconfig",
                 "--enable-gmp",
                 "--enable-gnutls",


### PR DESCRIPTION
Enabling mediafoundation drags in a dependency on mfplat.dll which
doesn't seem to be present on all Windows installations.