### PR TITLE
Update libvpx to fix security vulnerability

### DIFF
--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -314,7 +314,7 @@ if not os.path.exists(output_tarball):
                 "xvid",
                 "xz",
             ],
-            source_url="https://ffmpeg.org/releases/ffmpeg-5.1.2.tar.xz",
+            source_url="https://ffmpeg.org/releases/ffmpeg-5.1.3.tar.xz",
             build_arguments=[
                 "--disable-alsa",
                 "--disable-doc",

--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -258,8 +258,8 @@ if not os.path.exists(output_tarball):
         ),
         Package(
             name="vpx",
-            source_filename="vpx-1.11.0.tar.gz",
-            source_url="https://github.com/webmproject/libvpx/archive/v1.11.0.tar.gz",
+            source_filename="vpx-1.13.1.tar.gz",
+            source_url="https://github.com/webmproject/libvpx/archive/v1.13.1.tar.gz",
             build_arguments=[
                 "--disable-examples",
                 "--disable-tools",


### PR DESCRIPTION
libxvpx prior to version 1.13.1 suffers from a buffer overflow vulnerability, see CVE-2023-5217.