### PR TITLE
 Use the version of msys2 included in the runner

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -50,13 +50,13 @@ jobs:
         if: matrix.os == 'macos-13' || matrix.os == 'macos-14'
         run: |
           brew update
-          brew install pkg-config
           brew unlink gettext libidn2 libpng libtiff libunistring libx11 libxau libxcb libxdmcp little-cms2 unbound
       - uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
         with:
           install: base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-gperf mingw-w64-x86_64-nasm
           path-type: inherit
+          release: false
       - name: Build FFmpeg
         env:
           CIBW_ARCHS: ${{ matrix.arch }}

--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -73,8 +73,8 @@ codec_group = [
     Package(
         name="aom",
         requires=["cmake"],
-        source_url="https://storage.googleapis.com/aom-releases/libaom-3.2.0.tar.gz",
-        source_strip_components=0,
+        source_url="https://storage.googleapis.com/aom-releases/libaom-3.11.0.tar.gz",
+        source_strip_components=1,
         build_system="cmake",
         build_arguments=[
             "-DENABLE_DOCS=0",
@@ -309,10 +309,14 @@ def main():
         "--disable-libfontconfig",
         "--disable-libbluray",
         "--disable-libopenjpeg",
-        "--enable-mediafoundation" if plat == "Windows" else "--disable-mediafoundation",
+        (
+            "--enable-mediafoundation"
+            if plat == "Windows"
+            else "--disable-mediafoundation"
+        ),
         "--enable-gmp",
         "--enable-gnutls" if use_gnutls else "--disable-gnutls",
-        "--enable-libaom",
+        "--enable-libaom" if plat != "Windows" else "--disable-libaom",
         "--enable-libdav1d",
         "--enable-libmp3lame",
         "--enable-libopencore-amrnb",

--- a/scripts/cibuildpkg.py
+++ b/scripts/cibuildpkg.py
@@ -421,7 +421,7 @@ class Builder:
     def _mangle_path(self, path: str) -> str:
         if platform.system() == "Windows":
             path = path.replace(os.path.sep, "/")
-            if path[1] == ':':
+            if path[1] == ":":
                 path = f"/{path[0].lower()}{path[2:]}"
         return path
 


### PR DESCRIPTION
I have been getting this error on the Windows runner:
` ERROR: aom >= 2.0.0 not found using pkg-config`

I think it is because the paths in PKG_CONFIG_PATH are getting messed up.

ffbuild/config.log says:
`Can't find >=.pc in any of /c/cibw/vendor/lib/pkgconfig C \cibw\vendor\lib\pkgconfig;D \a\_temp\msys64\mingw64\lib\pkgconfig;D \a\_temp\msys64\mingw64\share\pkgconfig /usr/lib/pkgconfig /usr/share/pkgconfig`