### PR TITLE
Use UCRT64 for Windows build

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -26,6 +26,9 @@ jobs:
           - os: macos-13
             arch: x86_64
             shell: bash
+          - os: ubuntu-24.04-arm
+            arch: aarch64
+            shell: bash
           - os: ubuntu-24.04
             arch: i686
             shell: bash
@@ -35,9 +38,8 @@ jobs:
           - os: windows-latest
             arch: AMD64
             shell: 'msys2 {0}'
-          - os: ubuntu-24.04-arm
-            arch: aarch64
-            shell: bash
+            msys_system: UCRT64
+            msys_prefix: mingw-w64-ucrt-x86_64
     defaults:
       run:
         shell: ${{ matrix.shell }}
@@ -57,7 +59,8 @@ jobs:
       - uses: msys2/setup-msys2@v2
         if: matrix.os == 'windows-latest'
         with:
-          install: base-devel mingw-w64-x86_64-gcc mingw-w64-x86_64-gperf mingw-w64-x86_64-nasm openssl-devel
+          install: base-devel openssl-devel ${{ matrix.msys_prefix }}-cc ${{ matrix.msys_prefix }}-gperf ${{ matrix.msys_prefix }}-nasm
+          msystem: ${{ matrix.msys_system }}
           path-type: inherit
           release: false
       - name: Build FFmpeg

--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -338,7 +338,7 @@ def main():
 
     # Fix winpthreads breakage until the fix reaches msys2 repos.
     if plat == "Windows":
-        run(["patch", "-d", "C:/msys64/mingw64", "-i", os.path.join(builder.patch_dir, "winpthreads.patch"), "-p3"])
+        run(["patch", "-d", "C:/msys64/ucrt64", "-i", os.path.join(builder.patch_dir, "winpthreads.patch"), "-p3"])
 
     # install packages
     available_tools = set()


### PR DESCRIPTION
Nowadays UCRT64 is the default environment, not MINGW64.