### PR TITLE
Enable OpenH264 support

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -65,8 +65,8 @@ jobs:
       - name: Build FFmpeg
         env:
           CIBW_ARCHS: ${{ matrix.arch }}
-          CIBW_BEFORE_BUILD: python scripts/build-ffmpeg.py /tmp/vendor --community --enable-cuda
-          CIBW_BEFORE_BUILD_WINDOWS: python scripts\build-ffmpeg.py C:\cibw\vendor --community --enable-cuda
+          CIBW_BEFORE_BUILD: python scripts/build-ffmpeg.py /tmp/vendor --community
+          CIBW_BEFORE_BUILD_WINDOWS: python scripts\build-ffmpeg.py C:\cibw\vendor --community
           CIBW_BUILD: cp311-*
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: LD_LIBRARY_PATH=/tmp/vendor/lib:$LD_LIBRARY_PATH auditwheel repair -w {dest_dir} {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: delvewheel repair --add-path C:\cibw\vendor\bin -w {dest_dir} {wheel}

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,7 @@ Currently FFmpeg 7.1.1 is built with the following packages enabled for all plat
 - lame 3.100
 - ogg 1.3.5
 - opencore-amr 0.1.5
+- openh264 2.6.0
 - opus 1.5.2
 - speex 1.2.1
 - svt-av1 3.0.1

--- a/scripts/cibuildpkg.py
+++ b/scripts/cibuildpkg.py
@@ -117,10 +117,9 @@ def correct_configure(file_path: str) -> None:
 
 
 class When(IntEnum):
-    never = 0
+    always = 0
     community_only = 1
     commercial_only = 2
-    always = 3
 
 
 @dataclass(slots=True)


### PR DESCRIPTION
We also tidy up the build script by removing unnecessary options:

- The `--commercial` flag which is just the opposite of `--community`.
- The `--enable-cuda` flag since we apparently use it.