### PR TITLE
Enable libx265

### DIFF
--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -411,6 +411,7 @@ def main():
         ffmpeg_package.build_arguments.extend(
             [
                 "--enable-libx264",
+                "--enable-libx265",
                 "--disable-libopenh264",
                 "--enable-gpl",
             ]


### PR DESCRIPTION
x265 should be enabled for "community" builds. This fixes https://github.com/PyAV-Org/PyAV/issues/1890