### PR TITLE
Disable libxml2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,6 @@ Features
 Currently FFmpeg 7.1.1 is built with the following packages enabled for all platforms:
 
 - gmp 6.3.0
-- xml2 2.14.3
 - xz 5.6.3
 - aom 3.11.0
 - dav1d 1.4.1

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,6 @@ Features
 Currently FFmpeg 7.1.1 is built with the following packages enabled for all platforms:
 
 - gmp 6.3.0
-- xz 5.6.3
 - aom 3.11.0
 - dav1d 1.4.1
 - lame 3.100

--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -44,13 +44,6 @@ library_group = [
         # out-of-tree builds fail on Windows
         build_dir=".",
     ),
-    Package(
-        name="xml2",
-        source_url="https://download.gnome.org/sources/libxml2/2.14/libxml2-2.14.3.tar.xz",
-        sha256="6de55cacc8c2bc758f2ef6f93c313cb30e4dd5d84ac5d3c7ccbd9344d8cc6833",
-        requires=["xz"],
-        build_arguments=["--without-python"],
-    ),
 ]
 
 gnutls_group = [
@@ -372,6 +365,7 @@ def main():
     ffmpeg_package.build_arguments = [
         "--enable-alsa" if use_alsa else "--disable-alsa",
         "--disable-doc",
+        "--disable-libxml2",
         "--disable-libtheora",
         "--disable-libfreetype",
         "--disable-libfontconfig",
@@ -398,7 +392,6 @@ def main():
         "--enable-libvpx",
         "--enable-libwebp",
         "--enable-libxcb" if plat == "Linux" else "--disable-libxcb",
-        "--enable-libxml2" if community else "--disable-libxml2",
         "--enable-lzma",
         "--enable-zlib",
         "--enable-version3",

--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -23,21 +23,6 @@ def calculate_sha256(filename: str) -> str:
 
 library_group = [
     Package(
-        name="xz",
-        source_url="https://github.com/tukaani-project/xz/releases/download/v5.6.3/xz-5.6.3.tar.xz",
-        sha256="db0590629b6f0fa36e74aea5f9731dc6f8df068ce7b7bafa45301832a5eebc3a",
-        build_arguments=[
-            "--disable-doc",
-            "--disable-lzma-links",
-            "--disable-lzmadec",
-            "--disable-lzmainfo",
-            "--disable-nls",
-            "--disable-scripts",
-            "--disable-xz",
-            "--disable-xzdec",
-        ],
-    ),
-    Package(
         name="gmp",
         source_url="https://ftp.gnu.org/gnu/gmp/gmp-6.3.0.tar.xz",
         sha256="a3c2b80201b89e68616f4ad30bc66aee4927c3ce50e33929ca819d5c43538898",
@@ -306,7 +291,7 @@ def main():
 
     args = parser.parse_args()
 
-    dest_dir = args.destination
+    dest_dir = os.path.abspath(args.destination)
     community = args.community
 
     # Use ALSA only on Linux.
@@ -363,9 +348,10 @@ def main():
         )
 
     ffmpeg_package.build_arguments = [
-        "--enable-alsa" if use_alsa else "--disable-alsa",
+        "--disable-programs",
         "--disable-doc",
         "--disable-libxml2",
+        "--disable-lzma",  # or re-add xz package
         "--disable-libtheora",
         "--disable-libfreetype",
         "--disable-libfontconfig",
@@ -377,6 +363,7 @@ def main():
             else "--disable-mediafoundation"
         ),
         "--enable-gmp",
+        "--enable-alsa" if use_alsa else "--disable-alsa",
         "--enable-gnutls" if use_gnutls else "--disable-gnutls",
         "--enable-libaom",
         "--enable-libdav1d",
@@ -392,7 +379,6 @@ def main():
         "--enable-libvpx",
         "--enable-libwebp",
         "--enable-libxcb" if plat == "Linux" else "--disable-libxcb",
-        "--enable-lzma",
         "--enable-zlib",
         "--enable-version3",
     ]


### PR DESCRIPTION
To improve security. In their own words:

"This is open-source software written by hobbyists, maintained by a single volunteer, badly tested, written in a memory-unsafe language and full of security bugs. It is foolish to use this software to process untrusted data. As such, we treat security issues like any other bug."