### PR TITLE
Add AMD AMF

### DIFF
--- a/patches/amf-headers.patch
+++ b/patches/amf-headers.patch
@@ -1,0 +1,44 @@
+diff -crB --new-file amf-headers-v1.5.0/amf.pc.in amf-headers-v1.5.0_patched/amf.pc.in
+*** amf-headers-v1.5.0/amf.pc.in	1970-01-01 00:00:00.000000000 +0000
+--- amf-headers-v1.5.0_patched/amf.pc.in	2025-11-11 06:48:00.181040000 +0000
+***************
+*** 0 ****
+--- 1,7 ----
++ prefix=@@PREFIX@@
++ includedir=${prefix}/AMF
++ 
++ Name: amf
++ Description: The version of Advanced Media Framework (AMF) SDK headers
++ Version: 1.5.0
++ Cflags: -I${includedir}
+diff -crB --new-file amf-headers-v1.5.0/Makefile amf-headers-v1.5.0_patched/Makefile
+*** amf-headers-v1.5.0/Makefile	1970-01-01 00:00:00.000000000 +0000
+--- amf-headers-v1.5.0_patched/Makefile	2025-11-11 07:34:38.261171572 +0000
+***************
+*** 0 ****
+--- 1,25 ----
++ PREFIX = /usr/local
++ LIBDIR = lib
++ INSTALL = install
++ SED = sed
++ 
++ all:
++ ifeq ($(OS),Windows_NT)
++ 	$(SED) 's#@@PREFIX@@#$(shell cygpath -m ${PREFIX})#' amf.pc.in > amf.pc
++ else
++ 	$(SED) 's#@@PREFIX@@#$(PREFIX)#' amf.pc.in > amf.pc
++ endif
++ 
++ install: all
++ 	$(INSTALL) -m 0755 -d '$(DESTDIR)$(PREFIX)/include/AMF/components'
++ 	$(INSTALL) -m 0755 -d '$(DESTDIR)$(PREFIX)/include/AMF/core'
++ 	$(INSTALL) -m 0644 AMF/components/*.h '$(DESTDIR)$(PREFIX)/include/AMF/components'
++ 	$(INSTALL) -m 0644 AMF/core/*.h '$(DESTDIR)$(PREFIX)/include/AMF/core'
++ 	$(INSTALL) -m 0755 -d '$(DESTDIR)$(PREFIX)/$(LIBDIR)/pkgconfig'
++ 	$(INSTALL) -m 0644 amf.pc '$(DESTDIR)$(PREFIX)/$(LIBDIR)/pkgconfig'
++ 
++ uninstall:
++ 	rm -rf '$(DESTDIR)$(PREFIX)/include/AMF' '$(DESTDIR)$(PREFIX)/$(LIBDIR)/pkgconfig/amf.pc'
++ 
++ .PHONY: all install uninstall
++ 

--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -234,6 +234,13 @@ nvheaders_package = Package(
     build_system="make",
 )
 
+amfheaders_package = Package(
+    name="amf-headers",
+    source_url="https://github.com/GPUOpen-LibrariesAndSDKs/AMF/releases/download/v1.5.0/AMF-headers-v1.5.0.tar.gz",
+    sha256="d569647fa26f289affe81a206259fa92f819d06db1e80cc334559953e82a3f01",
+    build_system="make",
+)
+
 ffmpeg_package = Package(
     name="ffmpeg",
     source_url="https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz",
@@ -299,6 +306,9 @@ def main():
     # Use CUDA if supported.
     use_cuda = plat in {"Linux", "Windows"}
 
+    # Use AMD AMF if supported.
+    use_amf = plat in {"Linux", "Windows"}
+
     # Use GnuTLS only on Linux, FFmpeg has native TLS backends for macOS and Windows.
     use_gnutls = plat == "Linux"
 
@@ -341,8 +351,8 @@ def main():
         build_tools.append(
             Package(
                 name="nasm",
-                source_url="https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.bz2",
-                sha256="34fd26c70a277a9fdd54cb5ecf389badedaf48047b269d1008fbc819b24e80bc",
+                source_url="https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/nasm-2.16.03.tar.bz2",
+                sha256="bef3de159bcd61adf98bb7cc87ee9046e944644ad76b7633f18ab063edb29e57",
             )
         )
 
@@ -388,6 +398,9 @@ def main():
     if use_cuda:
         ffmpeg_package.build_arguments.extend(["--enable-nvenc", "--enable-nvdec"])
 
+    if use_amf:
+        ffmpeg_package.build_arguments.append("--enable-amf")
+
     if not community:
         ffmpeg_package.build_arguments.append("--enable-libfdk_aac")
 
@@ -414,6 +427,8 @@ def main():
         packages += [alsa_package]
     if use_cuda:
         packages += [nvheaders_package]
+    if use_amf:
+        packages += [amfheaders_package]
 
     if use_gnutls:
         packages += gnutls_group


### PR DESCRIPTION
This implements #186 (Support AMD AMF)

I tried to follow cuda/nv-headers as best as I could.

The AMF headers tarball only includes .h files so I patched in a Makefile so it can be build like nv-headers. (pkg-config and Makefile were copied from [nv-headers](https://github.com/FFmpeg/nv-codec-headers/tree/master) and adjusted to AMF)

Not tested on Windows