### PR TITLE
Add support for Intel QSV codecs

### DIFF
--- a/scripts/build-ffmpeg.py
+++ b/scripts/build-ffmpeg.py
@@ -241,6 +241,22 @@ amfheaders_package = Package(
     build_system="make",
 )
 
+libvpl_package = Package(
+    name="libvpl",
+    source_url="https://github.com/intel/libvpl/archive/refs/tags/v2.16.0.tar.gz",
+    sha256="d60931937426130ddad9f1975c010543f0da99e67edb1c6070656b7947f633b6",
+    requires=["cmake"],
+    build_system="cmake",
+    build_arguments=[
+        "-DINSTALL_LIB=ON",
+        "-DINSTALL_DEV=ON",
+        "-DINSTALL_EXAMPLES=OFF",
+        "-DBUILD_EXPERIMENTAL=OFF",
+        "-DBUILD_TESTS=OFF",
+        "-DBUILD_EXAMPLES=OFF",
+    ],
+)
+
 ffmpeg_package = Package(
     name="ffmpeg",
     source_url="https://ffmpeg.org/releases/ffmpeg-8.0.tar.xz",
@@ -308,6 +324,10 @@ def main():
 
     # Use AMD AMF if supported.
     use_amf = plat in {"Linux", "Windows"}
+
+    # Use Intel VPL (Video Processing Library) if supported to enable Intel QSV (Quick Sync Video)
+    # hardware encoders/decoders on modern integrated and discrete Intel GPUs.
+    use_libvpl = plat in {"Linux", "Windows"}
 
     # Use GnuTLS only on Linux, FFmpeg has native TLS backends for macOS and Windows.
     use_gnutls = plat == "Linux"
@@ -401,6 +421,9 @@ def main():
     if use_amf:
         ffmpeg_package.build_arguments.append("--enable-amf")
 
+    if use_libvpl:
+        ffmpeg_package.build_arguments.append("--enable-libvpl")
+
     if not community:
         ffmpeg_package.build_arguments.append("--enable-libfdk_aac")
 
@@ -429,6 +452,8 @@ def main():
         packages += [nvheaders_package]
     if use_amf:
         packages += [amfheaders_package]
+    if use_libvpl:
+        packages += [libvpl_package]
 
     if use_gnutls:
         packages += gnutls_group


### PR DESCRIPTION
Adds support for Intel hardware-accelerated QSV encoders and decoders available for discrete (Arc) and integrated (Xe) Intel GPUs.

### How to test

Check out this PR branch and build pyav-ffmpeg
```
cd pyav-ffmpeg
python -m venv .venv
source .venv/bin/activate
python scripts/build-ffmpeg.py pyav_ffmpeg_qsv_build
PYAV_FFMPEG_BUILD=$(pwd)/pyav_ffmpeg_qsv_build
```

Checkout PyAV and build it using the build artifacts from above
```
git clone https://github.com/PyAV-Org/PyAV.git
cd PyAV
python -m venv .venv
source .venv/bin/activate
pip install setuptools cython
python setup.py build_ext --inplace --ffmpeg-dir="$PYAV_FFMPEG_BUILD"
```

Check if qsv codecs show up
```
python -m av --codecs | grep qsv
 DEV.L. av1_qsv            AV1 (Intel Quick Sync Video acceleration)
 DEV.LS h264_qsv           H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (Intel Quick Sync Video acceleration)
 DEV.L. hevc_qsv           HEVC (Intel Quick Sync Video acceleration)
 DEVIL. mjpeg_qsv          MJPEG (Intel Quick Sync Video acceleration)
 DEV.L. mpeg2_qsv          MPEG-2 video (Intel Quick Sync Video acceleration)
 D.V.L. vc1_qsv            VC1 video (Intel Quick Sync Video acceleration)
 D.V.L. vp8_qsv            VP8 video (Intel Quick Sync Video acceleration)
 DEV.L. vp9_qsv            VP9 video (Intel Quick Sync Video acceleration)
 D.V.L. vvc_qsv            VVC video (Intel Quick Sync Video acceleration)
```

Similar to AMD or Nvidia codecs we need a runtime component to be able to use it. I installed these packages on ArchLinux. On other distros the package(s) may be named differently. I did not test on Windows.

```
sudo pacman -S libvpl vpl-gpu-rt
```

Test transcoding using `h264_qsv` encoder:
```
import av
import av.datasets

input_container = av.open(av.datasets.curated("pexels/time-lapse-video-of-night-sky-857195.mp4"))
output_container = av.open("h264_qsv_encoded.mp4", "w", options={})

input_stream = input_container.streams.video[0]
output_stream = output_container.add_stream('h264_qsv', input_stream.average_rate)
output_stream.width = input_stream.width
output_stream.height = input_stream.height
output_stream.pix_fmt = "nv12"

for frame in input_container.decode(video=0):
    packet = output_stream.encode(frame)
    if packet: output_container.mux(packet)

input_container.close()
output_container.close()
```

### Documentation:
* https://github.com/intel/libvpl
* https://trac.ffmpeg.org/wiki/Hardware/QuickSync